### PR TITLE
Fix mobile touch navigation on text elements

### DIFF
--- a/frontend/src/app/book/[id]/read/readBook.module.css
+++ b/frontend/src/app/book/[id]/read/readBook.module.css
@@ -22,6 +22,14 @@
     /* Allow vertical scrolling but prevent zoom on double tap */
     touch-action: pan-y;
   }
+  
+  /* Make text elements pass through touch events to parent for navigation */
+  .paginatedContent p,
+  .paginatedContent span,
+  .paginatedContent div,
+  .paginatedContent br {
+    pointer-events: none;
+  }
 }
 
 /* Mobile browser viewport fixes */


### PR DESCRIPTION
- Add pointer-events: none to text elements inside paginatedContent on mobile
- Allows touch events to pass through text elements to parent container
- Fixes issue where tapping directly on text didn't trigger page navigation
- Only applies to mobile devices (max-width: 768px)
- Maintains existing functionality on desktop devices